### PR TITLE
Update whitelist.ts

### DIFF
--- a/src/bot/voice/constants/whitelist.ts
+++ b/src/bot/voice/constants/whitelist.ts
@@ -1,1 +1,1 @@
-export const whitelist = ['884100077344419861']
+export const whitelist = ['884100077344419861', '1064595756515852419']


### PR DESCRIPTION
add gentleman

- [x] I Agree With: Введение:

Автоматическое исключение пользователей из чата или приложения при отключении входящего звука - это решение, которое может иметь серьезные негативные последствия для пользовательского опыта и общей динамики общения. В данном эссе мы рассмотрим несколько ключевых аспектов, почему такой подход может быть неэффективным и даже вредным.

Ограничение возможности мультизадачности:
Пользователи могут иметь различные причины для временного отключения входящего звука, например, чтобы сконцентрироваться на других задачах или избежать нежелательного шума из чата. Принуждать их оставаться подключенными к звуку, даже когда им это не нужно, лишает их возможности эффективно мультизадачить и может привести к отвлечению и снижению производительности.

Ограничение приватности и конфиденциальности:
Некоторые пользователи могут иметь причины для временного отключения звука из соображений конфиденциальности или приватности. Например, они могут хотеть обсудить что-то конфиденциальное по телефону или встретиться с кем-то в реальной жизни, не желая, чтобы их разговоры были слышимы в чате. Принудительное исключение пользователей при отключении звука нарушает их право на приватность и может создать недовольство.

Недоступность для пользователей с ограниченными возможностями:
Некоторые пользователи могут иметь физические или звуковые ограничения, которые делают использование звука затруднительным или невозможным. Принуждать их оставаться подключенными к звуку, даже когда им это неудобно или невозможно, создает барьеры для доступа и может привести к исключению определенных групп пользователей.

Потенциальные проблемы с безопасностью:
Принудительное исключение пользователей из чата при отключении звука может стать проблемой безопасности, так как это может создать возможность для несанкционированного доступа к чату или для нежелательного прослушивания и записи разговоров. Это особенно актуально в случае чувствительных обсуждений или деловых переговоров.

Ограничение свободы выражения:
Пользователи должны иметь возможность выбирать, когда им нужно включать или отключать звук в чате, чтобы соответствовать их собственным потребностям и предпочтениям. Принуждение их оставаться подключенными к звуку в любое время ограничивает их свободу выражения и контроля над своим опытом общения.
